### PR TITLE
Add CI GitHub actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,22 @@ jobs:
   rubocop:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v2
       - name: RuboCop
         uses: reviewdog/action-rubocop@v1
         with:
           github_token: ${{ secrets. REVIEWDOG_GITHUB_TOKEN }}
+  rspec:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      - name: Install dependencies
+        run: bundle install
+      - name: RSpec
+        run: bundle exec rspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  rubocop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: RuboCop
+        uses: reviewdog/action-rubocop@v1
+        with:
+          github_token: ${{ secrets. REVIEWDOG_GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # vending-machine-kata
+
+![ci](https://github.com/nickpellant/vending-machine-kata/workflows/ci/badge.svg)


### PR DESCRIPTION
Add CI workflow via GitHub actions. The CI workflow is expected to:

- [x] Run RuboCop
- [x] Run RSpec