### PR TITLE
Switch CI workflow rspec job to use container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
 
   rspec:
     runs-on: ubuntu-latest
+    container: ruby:2.7.1-buster
     services:
       postgres:
         image: postgres
@@ -35,10 +36,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Setup Ruby
-        uses: actions/setup-ruby@v1
-        with:
-          ruby-version: 2.7
       - name: Install dependencies
         run: bundle install
       - name: RSpec


### PR DESCRIPTION
By using a container we don't have to port map the postgres service.