### PR TITLE
Allow StockProduct command to update product stock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,6 @@
 name: ci
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
   rubocop:

--- a/lib/commands/vending_machine/stock_product.rb
+++ b/lib/commands/vending_machine/stock_product.rb
@@ -9,7 +9,9 @@ module Commands
     class StockProduct < ApplicationCommand
       include Import[
         'logger',
+        'repos.product_repo',
         'services.products.create_product',
+        'services.products.update_product_stock'
       ]
 
       option :name, Dry::Types['strict.string']
@@ -17,7 +19,46 @@ module Commands
       option :quantity_to_stock, Dry::Types['strict.integer']
 
       def call
-        result = create_product
+        @product = find_product
+
+        if product
+          update_product_stock
+        else
+          create_product
+        end
+      end
+
+      private
+
+      attr_reader :product
+
+      def find_product
+        product_repo.by_params(name: name, price: price)
+      end
+
+      def update_product_stock
+        result = super.call(product: product, quantity_to_stock: quantity_to_stock)
+
+        case result
+        when Entities::Product
+          log_product_stock_updated(result.quantity_in_stock)
+        when Dry::Validation::Result
+          log_product_stock_update_failed_validation
+        end
+      end
+
+      def log_product_stock_updated(new_quantity_in_stock)
+        logger.info(
+          "'#{name}' stock changed from #{product.quantity_in_stock} to #{new_quantity_in_stock}"
+        )
+      end
+
+      def log_product_stock_update_failed_validation
+        logger.error("Attempting to update stock for '#{name}' led to a validation error")
+      end
+
+      def create_product
+        result = super.call(name: name, price: price, quantity_in_stock: quantity_to_stock)
 
         case result
         when Entities::Product
@@ -25,12 +66,6 @@ module Commands
         when Dry::Validation::Result
           log_product_creation_failed_validation
         end
-      end
-
-      private
-
-      def create_product
-        super.call(name: name, price: price, quantity_in_stock: quantity_to_stock)
       end
 
       def log_product_created

--- a/lib/contracts/products/create_product_contract.rb
+++ b/lib/contracts/products/create_product_contract.rb
@@ -15,6 +15,10 @@ module Contracts
       rule(:price) do
         key.failure('must be greater than or equal to zero') if value.negative?
       end
+
+      rule(:quantity_in_stock) do
+        key.failure('must be greater than or equal to zero') if value.negative?
+      end
     end
   end
 end

--- a/lib/contracts/products/update_product_stock_contract.rb
+++ b/lib/contracts/products/update_product_stock_contract.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative '../application_contract'
+
+module Contracts
+  module Products
+    # Contract to validate product data for updating an existing products stock
+    class UpdateProductStockContract < ApplicationContract
+      schema do
+        required(:quantity_in_stock).filled(:integer)
+      end
+
+      rule(:quantity_in_stock) do
+        key.failure('must be greater than or equal to zero') if value.negative?
+      end
+    end
+  end
+end

--- a/lib/repos/product_repo.rb
+++ b/lib/repos/product_repo.rb
@@ -5,7 +5,7 @@ require_relative 'application_repo'
 module Repos
   # Convenience interface for product relations
   class ProductRepo < ApplicationRepo[:products]
-    commands(:create)
+    commands(:create, update: :by_pk)
 
     def all
       products.to_a

--- a/lib/repos/product_repo.rb
+++ b/lib/repos/product_repo.rb
@@ -11,6 +11,10 @@ module Repos
       products.to_a
     end
 
+    def by_params(params)
+      products.where(params).one
+    end
+
     def count
       products.count
     end

--- a/lib/services/products/update_product_stock.rb
+++ b/lib/services/products/update_product_stock.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'entities/product'
+require 'services/application_service'
+
+module Services
+  module Products
+    # Validate changed data and updates existing product's quantity in stock
+    class UpdateProductStock < ApplicationService
+      include Import[
+        'contracts.products.update_product_stock_contract',
+        'repos.product_repo',
+      ]
+
+      option :product, Dry::Types().Instance(Entities::Product)
+      option :quantity_to_stock, Dry::Types['strict.integer']
+
+      def call
+        validation_result = validate
+
+        if validation_result.success?
+          product_repo.update(product.id, validation_result.to_h)
+        else
+          validation_result
+        end
+      end
+
+      private
+
+      def unvalidated_params
+        { quantity_in_stock: product.quantity_in_stock + quantity_to_stock }
+      end
+
+      def validate
+        update_product_stock_contract.call(unvalidated_params)
+      end
+    end
+  end
+end

--- a/spec/contracts/products/create_product_contract_spec.rb
+++ b/spec/contracts/products/create_product_contract_spec.rb
@@ -34,6 +34,12 @@ RSpec.describe Contracts::Products::CreateProductContract do
   describe '#errors[:quantity_in_stock]' do
     it_behaves_like 'a required integer schema value' do
       let(:value_key) { :quantity_in_stock }
+
+      context 'when value is less than zero' do
+        let(:params) { { value_key => -1 } }
+
+        it { is_expected.to eql(['must be greater than or equal to zero']) }
+      end
     end
   end
 end

--- a/spec/contracts/products/update_product_stock_contract_spec.rb
+++ b/spec/contracts/products/update_product_stock_contract_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'support/shared_examples/a_contract_with_required_values'
+require 'support/shared_examples/a_required_integer_schema_value'
+
+require 'contracts/products/update_product_stock_contract'
+
+RSpec.describe Contracts::Products::UpdateProductStockContract do
+  it_behaves_like 'a contract with required values' do
+    let(:required_values) { %i[quantity_in_stock] }
+  end
+
+  describe '#errors[:quantity_in_stock]' do
+    it_behaves_like 'a required integer schema value' do
+      let(:value_key) { :quantity_in_stock }
+
+      context 'when value is less than zero' do
+        let(:params) { { value_key => -1 } }
+
+        it { is_expected.to eql(['must be greater than or equal to zero']) }
+      end
+    end
+  end
+end

--- a/spec/repos/product_repo_spec.rb
+++ b/spec/repos/product_repo_spec.rb
@@ -16,6 +16,25 @@ RSpec.describe Repos::ProductRepo do
     end
   end
 
+  describe '#by_params' do
+    subject(:by_params) { product_repo.by_params(params) }
+
+    context 'when product found' do
+      let(:product) { Factory[:product] }
+      let(:params) { { name: product.name } }
+
+      it 'is expected to return the product' do
+        expect(by_params).to eql(product)
+      end
+    end
+
+    context 'when product not found' do
+      let(:params) { { name: 'Name' } }
+
+      it { expect(by_params).to be_nil }
+    end
+  end
+
   describe '#count' do
     subject(:count) { product_repo.count }
 

--- a/spec/services/products/update_product_stock_spec.rb
+++ b/spec/services/products/update_product_stock_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'contracts/products/update_product_stock_contract'
+require 'repos/product_repo'
+require 'services/products/update_product_stock'
+
+RSpec.describe Services::Products::UpdateProductStock do
+  subject(:call) { described_class.call(product: product, quantity_to_stock: quantity_to_stock) }
+
+  let(:product) { Factory.structs[:product] }
+
+  let(:update_product_stock_contract) do
+    instance_spy(Contracts::Products::UpdateProductStockContract)
+  end
+  let(:product_repo) { instance_spy(Repos::ProductRepo) }
+  let(:validation_result) { instance_spy(Dry::Validation::Result) }
+
+  before do
+    allow(update_product_stock_contract).to(
+      receive(:call).with(unvalidated_params).and_return(validation_result)
+    )
+    App.stub('contracts.products.update_product_stock_contract', update_product_stock_contract)
+    App.stub('repos.product_repo', product_repo)
+  end
+
+  context 'when change to quantity in stock is valid' do
+    let(:quantity_to_stock) { 1 }
+    let(:new_quantity_in_stock) { product.quantity_in_stock + quantity_to_stock }
+    let(:unvalidated_params) { { quantity_in_stock: new_quantity_in_stock } }
+    let(:validated_params) { unvalidated_params }
+
+    before do
+      allow(validation_result).to receive(:success?).and_return(true)
+      allow(validation_result).to receive(:to_h).and_return(validated_params)
+
+      allow(product_repo).to receive(:update).with(product.id, validated_params).and_return(product)
+    end
+
+    it 'validates the product data' do
+      call
+
+      expect(update_product_stock_contract).to have_received(:call).with(unvalidated_params)
+    end
+
+    it 'updates the product' do
+      call
+
+      expect(product_repo).to have_received(:update).with(product.id, validated_params)
+    end
+
+    it 'returns the created product' do
+      expect(call).to be(product)
+    end
+  end
+
+  context 'when change to quantity in stock is invalid' do
+    let(:quantity_to_stock) { -(product.quantity_in_stock + 1) }
+    let(:new_quantity_in_stock) { -1 }
+    let(:unvalidated_params) { { quantity_in_stock: new_quantity_in_stock } }
+
+    before { allow(validation_result).to receive(:success?).and_return(false) }
+
+    it 'validates the product data' do
+      call
+
+      expect(update_product_stock_contract).to have_received(:call).with(unvalidated_params)
+    end
+
+    it 'does not update the product' do
+      call
+
+      expect(product_repo).not_to have_received(:update)
+    end
+
+    it 'returns the validation result' do
+      expect(call).to be(validation_result)
+    end
+  end
+end


### PR DESCRIPTION
When a product is already stocked, we should update its quantity in stock rather than create a new product.